### PR TITLE
feat: Enumerate and benchmark all system GPUs individually

### DIFF
--- a/src/GpuStreamingDemo.Core/AcceleratorFactory.cs
+++ b/src/GpuStreamingDemo.Core/AcceleratorFactory.cs
@@ -1,6 +1,7 @@
 using ILGPU;
 using ILGPU.Runtime;
 using ILGPU.Runtime.CPU;
+using ILGPU.Runtime.Cuda;
 
 namespace GpuStreamingDemo.Core;
 
@@ -20,17 +21,69 @@ public enum AcceleratorKind
 }
 
 /// <summary>
+/// Describes an available compute device on the system.
+/// </summary>
+/// <param name="Index">Zero-based device index for CLI targeting.</param>
+/// <param name="Name">Human-readable device name.</param>
+/// <param name="Type">Accelerator type (CPU, CUDA, OpenCL).</param>
+/// <param name="MemoryBytes">Total device memory in bytes (0 if unavailable).</param>
+/// <param name="ComputeCapability">CUDA compute capability string, or null for non-CUDA devices.</param>
+public sealed record DeviceInfo(
+    int Index,
+    string Name,
+    AcceleratorType Type,
+    long MemoryBytes,
+    string? ComputeCapability
+);
+
+/// <summary>
 /// Factory for creating and configuring ILGPU compute accelerators.
+/// Supports device enumeration and targeting specific devices by index.
 /// </summary>
 public static class AcceleratorFactory
 {
+    /// <summary>
+    /// Enumerates all available compute devices on the system.
+    /// </summary>
+    /// <returns>A list of <see cref="DeviceInfo"/> describing each available device.</returns>
+    public static List<DeviceInfo> EnumerateDevices()
+    {
+        using var context = Context.CreateDefault();
+        var devices = new List<DeviceInfo>();
+        int index = 0;
+
+        foreach (var device in context.Devices)
+        {
+            string? computeCap = null;
+            long memoryBytes = 0;
+
+            if (device is CudaDevice cudaDev)
+            {
+                computeCap = $"{cudaDev.Architecture}";
+                memoryBytes = cudaDev.MemorySize;
+            }
+            else if (device.AcceleratorType != AcceleratorType.CPU)
+            {
+                memoryBytes = device.MemorySize;
+            }
+
+            devices.Add(new DeviceInfo(
+                Index: index++,
+                Name: device.Name,
+                Type: device.AcceleratorType,
+                MemoryBytes: memoryBytes,
+                ComputeCapability: computeCap
+            ));
+        }
+
+        return devices;
+    }
+
     /// <summary>
     /// Creates an ILGPU context and accelerator of the specified kind.
     /// </summary>
     /// <param name="kind">The type of accelerator to create.</param>
     /// <returns>A tuple containing the created <see cref="Context"/> and <see cref="Accelerator"/>.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the requested accelerator type is not available on the system.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when an unknown accelerator kind is specified.</exception>
     public static (Context Context, Accelerator Accelerator) Create(AcceleratorKind kind)
     {
         var context = Context.CreateDefault();
@@ -38,10 +91,7 @@ public static class AcceleratorFactory
         Accelerator accelerator = kind switch
         {
             AcceleratorKind.Auto   => context.GetPreferredDevice(preferCPU: false).CreateAccelerator(context),
-
-            // CPU accelerator creation is provided by ILGPU.Runtime.CPU
             AcceleratorKind.Cpu    => context.CreateCPUAccelerator(0),
-
             AcceleratorKind.Cuda   => CreateByType(context, AcceleratorType.Cuda),
             AcceleratorKind.OpenCL => CreateByType(context, AcceleratorType.OpenCL),
 
@@ -52,12 +102,60 @@ public static class AcceleratorFactory
     }
 
     /// <summary>
-    /// Creates an accelerator for a specific <see cref="AcceleratorType"/>.
+    /// Creates an ILGPU context and accelerator for a specific device by index.
+    /// The index corresponds to the order returned by <see cref="EnumerateDevices"/>.
     /// </summary>
-    /// <param name="context">The ILGPU context to use.</param>
-    /// <param name="type">The type of accelerator to create.</param>
-    /// <returns>An <see cref="Accelerator"/> instance of the specified type.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when no device of the specified type is found.</exception>
+    /// <param name="deviceIndex">Zero-based device index.</param>
+    /// <returns>A tuple containing the created <see cref="Context"/>, <see cref="Accelerator"/>, and device name.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the device index is invalid.</exception>
+    public static (Context Context, Accelerator Accelerator, string DeviceName) CreateByIndex(int deviceIndex)
+    {
+        var context = Context.CreateDefault();
+        var allDevices = context.Devices.ToList();
+
+        if (deviceIndex < 0 || deviceIndex >= allDevices.Count)
+        {
+            context.Dispose();
+            throw new ArgumentOutOfRangeException(nameof(deviceIndex),
+                $"Device index {deviceIndex} is out of range. Available devices: 0-{allDevices.Count - 1}");
+        }
+
+        var device = allDevices[deviceIndex];
+        var accelerator = device.AcceleratorType == AcceleratorType.CPU
+            ? context.CreateCPUAccelerator(0)
+            : device.CreateAccelerator(context);
+
+        return (context, accelerator, device.Name);
+    }
+
+    /// <summary>
+    /// Creates contexts and accelerators for all available devices.
+    /// Each entry must be disposed separately by the caller.
+    /// </summary>
+    /// <returns>A list of tuples containing context, accelerator, and device name.</returns>
+    public static List<(Context Context, Accelerator Accelerator, string DeviceName)> CreateAll()
+    {
+        // We need a temporary context to discover devices, then create individual contexts
+        // because ILGPU contexts can't be shared across some device types.
+        var deviceInfos = EnumerateDevices();
+        var results = new List<(Context, Accelerator, string)>();
+
+        foreach (var info in deviceInfos)
+        {
+            try
+            {
+                var (ctx, accel, name) = CreateByIndex(info.Index);
+                results.Add((ctx, accel, name));
+            }
+            catch
+            {
+                // Skip devices that fail to initialise
+            }
+        }
+
+        return results;
+    }
+
     private static Accelerator CreateByType(Context context, AcceleratorType type)
     {
         var device = context.Devices.FirstOrDefault(d => d.AcceleratorType == type)

--- a/src/GpuStreamingDemo.Core/BenchmarkResult.cs
+++ b/src/GpuStreamingDemo.Core/BenchmarkResult.cs
@@ -5,6 +5,7 @@ namespace GpuStreamingDemo.Core;
 /// </summary>
 /// <param name="TaskName">The name of the benchmark task that was executed.</param>
 /// <param name="Accelerator">The type of accelerator used for the benchmark.</param>
+/// <param name="DeviceName">The specific device name (e.g. "NVIDIA GeForce RTX 4070 Ti").</param>
 /// <param name="BatchSize">The number of elements processed in each batch.</param>
 /// <param name="Iterations">The number of benchmark iterations executed.</param>
 /// <param name="AvgLatencyMs">The average latency per iteration in milliseconds.</param>
@@ -13,6 +14,7 @@ namespace GpuStreamingDemo.Core;
 public sealed record BenchmarkResult(
     string TaskName,
     AcceleratorKind Accelerator,
+    string DeviceName,
     int BatchSize,
     int Iterations,
     double AvgLatencyMs,

--- a/src/GpuStreamingDemo.Core/DoubleBufferedBenchmarkRunner.cs
+++ b/src/GpuStreamingDemo.Core/DoubleBufferedBenchmarkRunner.cs
@@ -8,6 +8,7 @@ namespace GpuStreamingDemo.Core;
 /// </summary>
 /// <param name="TaskName">The name of the benchmark task.</param>
 /// <param name="Accelerator">The accelerator type used.</param>
+/// <param name="DeviceName">The specific device name (e.g. "NVIDIA GeForce RTX 4070 Ti").</param>
 /// <param name="BatchSize">Elements per batch.</param>
 /// <param name="Iterations">Number of timed iterations.</param>
 /// <param name="AvgLatencyMs">Average latency per iteration in milliseconds.</param>
@@ -19,6 +20,7 @@ namespace GpuStreamingDemo.Core;
 public sealed record DoubleBufferedResult(
     string TaskName,
     AcceleratorKind Accelerator,
+    string DeviceName,
     int BatchSize,
     int Iterations,
     double AvgLatencyMs,
@@ -163,6 +165,7 @@ public static class DoubleBufferedBenchmarkRunner
             return new DoubleBufferedResult(
                 task.Name + " (2xBuf)",
                 acceleratorKind,
+                accelerator.Name,
                 batchSize,
                 iterations,
                 doubleAvgMs,


### PR DESCRIPTION
## Summary
Implements device enumeration and per-device GPU targeting (issue #19).

## Changes

### Core
- **DeviceInfo record** + **EnumerateDevices()** in AcceleratorFactory
- **CreateByIndex(int)** and **CreateAll()** for targeting specific devices
- **BenchmarkResult.DeviceName** and **DoubleBufferedResult.DeviceName** fields
- **GpuBenchmarkRunner.RunOnDevice()** with shared RunOnAccelerator() refactor
- Graceful failure: devices that fail to initialise are skipped

### CLI
- **--list-devices** — enumerate all compute devices and exit
- **--device <index>** — target a specific device by index
- **--accel all** now runs on every discovered device individually

### Results Output
- Device column in results table (e.g. 'NVIDIA GeForce RTX 4070 Ti' vs 'Intel UHD Graphics 770')

### README
- New CLI args documented
- Device enumeration flow diagram (mermaid)
- Updated results table with Device column
- Example --list-devices output

Closes #19